### PR TITLE
Copy txid, not payment hash, to clipboard on boost send

### DIFF
--- a/src/components/modals/send-modal/index.js
+++ b/src/components/modals/send-modal/index.js
@@ -144,7 +144,7 @@ const SendModal = ({
           result = await window.webln.sendPayment(data.bolt11_invoice);
           navigator.clipboard.writeText(result.paymentHash);
           toast.success(
-            `Transaction sent: ${result.paymentHash}, copied to clipboard`,
+            `Transaction sent: ${fundedPsbt.extractTransaction().getId()}, copied to clipboard`,
           );
         } else {
           result = data.bolt11_invoice;


### PR DESCRIPTION
This was a bug